### PR TITLE
Check new finger print added on iOS

### DIFF
--- a/ios/BiometricNext.mm
+++ b/ios/BiometricNext.mm
@@ -2,11 +2,9 @@
 
 @interface RCT_EXTERN_MODULE(BiometricNext, NSObject)
 
-RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
-                 withResolver:(RCTPromiseResolveBlock)resolve
-                 withRejecter:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(enableBioMetric:(NSString *)title subtitle:(NSString *)subtitle callback:(RCTResponseSenderBlock)callback)
+
+RCT_EXTERN_METHOD(checkNewFingerPrintAdded:(RCTResponseSenderBlock)callback)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/ios/BiometricNext.swift
+++ b/ios/BiometricNext.swift
@@ -46,7 +46,11 @@ class BiometricNext: NSObject {
     }
     
     @objc func checkNewFingerPrintAdded(_ callback: @escaping RCTResponseSenderBlock) {
-        callback([LAContext.biometricsChanged()])
+        if LAContext.biometricsChanged() {
+            callback(["NEW_FINGERPRINT_ADDED"])
+        }else {
+            callback(["CONTINUE"])
+        }
     }
 }
 

--- a/ios/BiometricNext.swift
+++ b/ios/BiometricNext.swift
@@ -1,15 +1,16 @@
 import LocalAuthentication
+
+let biometricKey = "BiometricsPolicyState"
+
 @objc(BiometricNext)
 class BiometricNext: NSObject {
 
-  @objc(multiply:withB:withResolver:withRejecter:)
-  func multiply(a: Float, b: Float, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
-    resolve(a*b)
-  }
+    
     
     @objc func enableBioMetric(_ title: String,subtitle: String, callback: @escaping RCTResponseSenderBlock) -> Void {
         let localAuthenticationContext = LAContext()
         localAuthenticationContext.localizedFallbackTitle = title
+        
         var authError: NSError?
         let reasonString = subtitle
         if localAuthenticationContext.canEvaluatePolicy(.deviceOwnerAuthentication, error: &authError) {
@@ -42,5 +43,40 @@ class BiometricNext: NSObject {
             }
             callback([authError ?? "Something went wrong"])
         }
+    }
+    
+    @objc func checkNewFingerPrintAdded(_ callback: @escaping RCTResponseSenderBlock) {
+        callback([LAContext.biometricsChanged()])
+    }
+}
+
+
+extension LAContext {
+    
+    static var savedBiometricPolicyState: Data? {
+        get {
+            UserDefaults.standard.data(forKey: biometricKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: biometricKey)
+        }
+    }
+    
+    static func biometricsChanged() -> Bool {
+        let context = LAContext()
+        var error: NSError?
+        
+        context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+        
+        if error == nil && LAContext.savedBiometricPolicyState == nil {
+            LAContext.savedBiometricPolicyState = context.evaluatedPolicyDomainState
+            return false
+        }
+        
+        if let domainState = context.evaluatedPolicyDomainState, domainState != LAContext.savedBiometricPolicyState {
+            return true
+        }
+        
+        return false
     }
 }


### PR DESCRIPTION
Hi there.
Here is my contribution implementing the checkNewFingerPrint method on iOS, also removed from iOS the multiply method from the boilerplate.

On this implementation I'm extending the LAContext class and adding a static variable ```savedBiometricPolicyState``` to store the previous state from ```savedBiometricPolicyState``` when it's ```nil``` and comparing it with the current state when it's filled.
When the current and previous state are equals I'm returning ```true``` otherwise, returns ```false```.